### PR TITLE
Change websocket url

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -2,5 +2,5 @@
 ENV_VALUE="some-development-value"
 # For development let's enable sentry for a little bit
 SENTRY_DSN="https://d2d3cf9679a046acbac54b0af2793b15@sentry.io/5188631"
-WEBSOCKET_URL="wss://0a4nr0hbsk.execute-api.eu-west-2.amazonaws.com/dev/"
+WEBSOCKET_URL="wss://06prj0j7w1.execute-api.eu-west-2.amazonaws.com/dev"
 VERSION="local-dev"

--- a/.env.production
+++ b/.env.production
@@ -1,5 +1,5 @@
 # Production Values - BE CAREFUL! Any sensitive values should NOT be stored here - use env variables in CircleCI
 ENV_VALUE="some-production-value"
 SENTRY_DSN="https://d2d3cf9679a046acbac54b0af2793b15@sentry.io/5188631"
-WEBSOCKET_URL="wss://0a4nr0hbsk.execute-api.eu-west-2.amazonaws.com/dev/"
+WEBSOCKET_URL="wss://06prj0j7w1.execute-api.eu-west-2.amazonaws.com/dev"
 VERSION="local-production"

--- a/.env.staging
+++ b/.env.staging
@@ -1,5 +1,5 @@
 # Staging Values - BE CAREFUL! Any sensitive values should NOT be stored here - use env variables in CircleCI
 ENV_VALUE="some-staging-value"
 SENTRY_DSN="https://d2d3cf9679a046acbac54b0af2793b15@sentry.io/5188631"
-WEBSOCKET_URL="wss://0a4nr0hbsk.execute-api.eu-west-2.amazonaws.com/dev/"
+WEBSOCKET_URL="wss://06prj0j7w1.execute-api.eu-west-2.amazonaws.com/dev"
 VERSION="local-staging"

--- a/src/components/Layout/index.tsx
+++ b/src/components/Layout/index.tsx
@@ -8,7 +8,10 @@ export const Layout: React.FC = (props) => (
   <div className={styles.layout}>
     <div className={styles.header}>
       <h1>
-        <img src={favicon} /> {!localStorage.getItem('WEBSOCKET_URL') ? 'Janky Werewolf' : 'You are currently playing against a non-production version of the game'}
+        <img src={favicon} />
+        {!localStorage.getItem('WEBSOCKET_URL') ? 
+        'Janky Werewolf' : 
+        'You are currently playing against a non-production version of the game'}
       </h1>
     </div>
     <div className={styles.content}>

--- a/src/components/Layout/index.tsx
+++ b/src/components/Layout/index.tsx
@@ -9,11 +9,9 @@ export const Layout: React.FC = (props) => (
     <div className={styles.header}>
       <h1>
         <img src={favicon} />
-        {
-        !localStorage.getItem('WEBSOCKET_URL')
-        ? 'Janky Werewolf'
-        : 'You are currently playing against a non-production version of the game'
-        }
+        {!localStorage.getItem('WEBSOCKET_URL')
+          ? 'Janky Werewolf'
+          : 'You are currently playing against a non-production version of the game'}
       </h1>
     </div>
     <div className={styles.content}>

--- a/src/components/Layout/index.tsx
+++ b/src/components/Layout/index.tsx
@@ -9,9 +9,11 @@ export const Layout: React.FC = (props) => (
     <div className={styles.header}>
       <h1>
         <img src={favicon} />
-        {!localStorage.getItem('WEBSOCKET_URL') ? 
-        'Janky Werewolf' : 
-        'You are currently playing against a non-production version of the game'}
+        {
+        !localStorage.getItem('WEBSOCKET_URL')
+        ? 'Janky Werewolf'
+        : 'You are currently playing against a non-production version of the game'
+        }
       </h1>
     </div>
     <div className={styles.content}>

--- a/src/components/Layout/index.tsx
+++ b/src/components/Layout/index.tsx
@@ -8,7 +8,7 @@ export const Layout: React.FC = (props) => (
   <div className={styles.layout}>
     <div className={styles.header}>
       <h1>
-        <img src={favicon} /> Janky Werewolf
+        <img src={favicon} /> {!localStorage.getItem('WEBSOCKET_URL') ? 'Janky Werewolf' : 'You are currently playing against a non-production version of the game'}
       </h1>
     </div>
     <div className={styles.content}>

--- a/src/provider/Village/WebSocket/index.ts
+++ b/src/provider/Village/WebSocket/index.ts
@@ -209,8 +209,8 @@ export class WebSocketVillageProvider implements VillageProvider {
   }
 
   private initSocket(): void {
-    const websocketUrl = localStorage.getItem('WEBSOCKET_URL') ||
-      process.env.WEBSOCKET_URL;
+    const websocketUrl =
+      localStorage.getItem('WEBSOCKET_URL') || process.env.WEBSOCKET_URL;
     if (!websocketUrl) {
       throw new Error('No WEBSOCKET_URL defined in env vars');
     }

--- a/src/provider/Village/WebSocket/index.ts
+++ b/src/provider/Village/WebSocket/index.ts
@@ -209,7 +209,8 @@ export class WebSocketVillageProvider implements VillageProvider {
   }
 
   private initSocket(): void {
-    const websocketUrl = localStorage.getItem('WEBSOCKET_URL') || process.env.WEBSOCKET_URL;
+    const websocketUrl = localStorage.getItem('WEBSOCKET_URL') ||
+      process.env.WEBSOCKET_URL;
     if (!websocketUrl) {
       throw new Error('No WEBSOCKET_URL defined in env vars');
     }

--- a/src/provider/Village/WebSocket/index.ts
+++ b/src/provider/Village/WebSocket/index.ts
@@ -209,11 +209,12 @@ export class WebSocketVillageProvider implements VillageProvider {
   }
 
   private initSocket(): void {
-    if (!process.env.WEBSOCKET_URL) {
+    let websocketUrl = localStorage.getItem('WEBSOCKET_URL') || process.env.WEBSOCKET_URL;
+    if (!websocketUrl) {
       throw new Error('No WEBSOCKET_URL defined in env vars');
     }
 
-    this.socket = new WebSocket(process.env.WEBSOCKET_URL);
+    this.socket = new WebSocket(websocketUrl);
     this.socket.onmessage = this.onSocketMessage.bind(this);
   }
 

--- a/src/provider/Village/WebSocket/index.ts
+++ b/src/provider/Village/WebSocket/index.ts
@@ -209,7 +209,7 @@ export class WebSocketVillageProvider implements VillageProvider {
   }
 
   private initSocket(): void {
-    let websocketUrl = localStorage.getItem('WEBSOCKET_URL') || process.env.WEBSOCKET_URL;
+    const websocketUrl = localStorage.getItem('WEBSOCKET_URL') || process.env.WEBSOCKET_URL;
     if (!websocketUrl) {
       throw new Error('No WEBSOCKET_URL defined in env vars');
     }


### PR DESCRIPTION
## ✅ What & Why

Updated the websocket URL to point at the new "production" API for the backend so that the old API can be decommissioned.
Added the ability to override the baked in URL with a value from localStorage. Useful for quickly switching between backend API versions from **any** frontend build (including the current production version). If you are using the websocket URL override the header text will be changed to make it obvious (see screenshot).

## 🧪 Tests

- [] Currently no tests for this functionality but happy to discuss.

<!-- Ensure you've covered what's required. Put an "x" between the square brackets to fill in the checkbox -->

## 📸 Screenshots

![image](https://user-images.githubusercontent.com/4058741/101071602-bef39b00-3594-11eb-99cc-95ac0a2db3a2.png)

<!--- Any necessary screenshots. If it's a UI change, there should be something here --->

## 📓 Notes

<!--- Anything else you may want to talk about/get feedback on relative to this work --->
