### PR TITLE
Add lycan role to client

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,3 +70,6 @@ public/api-docs.html
 
 # Firebase cache
 .firebase/
+
+# vscode
+.vscode

--- a/src/components/PlayerWrapper/index.tsx
+++ b/src/components/PlayerWrapper/index.tsx
@@ -22,13 +22,15 @@ interface Props {
 const ROLE_TEXT = {
   [PLAYER_ROLE.VILLAGER]: 'No special powers',
   [PLAYER_ROLE.SEER]:
-    "Each night, choose someone and find out if they're good or evil",
+    "Each night, choose someone and find out if they're good or evil.",
   [PLAYER_ROLE.BODYGUARD]:
     'Each night, choose someone to protect. If the werewolves try to kill them, they will be saved. You cannot guard the same person on consecutive nights.',
   [PLAYER_ROLE.WEREWOLF]:
     'Each night, choose someone to kill. All werewolves must agree.',
   [PLAYER_ROLE.MODERATOR]:
     "You are running the game! Do your talking and explain what's happening.",
+  [PLAYER_ROLE.LYCAN]:
+    'No special powers but you will appear to the seer as a werewolf.',
   [PLAYER_ROLE.UNKNOWN]:
     'You should never see this. If you do, tell James/Mike',
 };
@@ -143,20 +145,24 @@ export const PlayerWrapper: React.FC<Props> = (props) => {
       <div className={styles.players}>
         <h3>Players</h3>
         <table>
-          <tr>
-            <th>Name</th>
-            <th>Team</th>
-            <th>Role</th>
-            <th>Alive</th>
-          </tr>
-          {props.players.map((player) => (
-            <tr key={player.name}>
-              <td>{player.name}</td>
-              <td>{player.attributes.team}</td>
-              <td>{player.attributes.role}</td>
-              <td>{player.attributes.alive ? 'Alive' : 'Dead'}</td>
+          <thead>
+            <tr>
+              <th>Name</th>
+              <th>Team</th>
+              <th>Role</th>
+              <th>Alive</th>
             </tr>
-          ))}
+          </thead>
+          <tbody>
+            {props.players.map((player) => (
+              <tr key={player.name}>
+                <td>{player.name}</td>
+                <td>{player.attributes.team}</td>
+                <td>{player.attributes.role}</td>
+                <td>{player.attributes.alive ? 'Alive' : 'Dead'}</td>
+              </tr>
+            ))}
+          </tbody>
         </table>
       </div>
     </div>

--- a/src/components/ViewController/matrix.ts
+++ b/src/components/ViewController/matrix.ts
@@ -27,6 +27,7 @@ export const COMPONENT_MATRIX: {
     [PLAYER_ROLE.MODERATOR]: LynchPickSinglePlayer,
     [PLAYER_ROLE.SEER]: DaytimeTextOnly,
     [PLAYER_ROLE.VILLAGER]: DaytimeTextOnly,
+    [PLAYER_ROLE.LYCAN]: DaytimeTextOnly,
     [PLAYER_ROLE.WEREWOLF]: DaytimeTextOnly,
   },
   [PHASE_NAME.SEER]: {
@@ -34,6 +35,7 @@ export const COMPONENT_MATRIX: {
     [PLAYER_ROLE.MODERATOR]: NonSeerTextOnly,
     [PLAYER_ROLE.SEER]: SeerPickSinglePlayer,
     [PLAYER_ROLE.VILLAGER]: NonSeerTextOnly,
+    [PLAYER_ROLE.LYCAN]: NonSeerTextOnly,
     [PLAYER_ROLE.WEREWOLF]: NonSeerTextOnly,
   },
   [PHASE_NAME.BODYGUARD]: {
@@ -41,6 +43,7 @@ export const COMPONENT_MATRIX: {
     [PLAYER_ROLE.MODERATOR]: NonBodyguardTextOnly,
     [PLAYER_ROLE.SEER]: NonBodyguardTextOnly,
     [PLAYER_ROLE.VILLAGER]: NonBodyguardTextOnly,
+    [PLAYER_ROLE.LYCAN]: NonBodyguardTextOnly,
     [PLAYER_ROLE.WEREWOLF]: NonBodyguardTextOnly,
   },
   [PHASE_NAME.WEREWOLF]: {
@@ -48,6 +51,7 @@ export const COMPONENT_MATRIX: {
     [PLAYER_ROLE.MODERATOR]: NonWerewolfTextOnly,
     [PLAYER_ROLE.SEER]: NonWerewolfTextOnly,
     [PLAYER_ROLE.VILLAGER]: NonWerewolfTextOnly,
+    [PLAYER_ROLE.LYCAN]: NonWerewolfTextOnly,
     [PLAYER_ROLE.WEREWOLF]: WerewolfVoteSinglePlayer,
   },
   [PHASE_NAME.END]: {
@@ -55,6 +59,7 @@ export const COMPONENT_MATRIX: {
     [PLAYER_ROLE.MODERATOR]: WinLoss,
     [PLAYER_ROLE.SEER]: WinLoss,
     [PLAYER_ROLE.VILLAGER]: WinLoss,
+    [PLAYER_ROLE.LYCAN]: WinLoss,
     [PLAYER_ROLE.WEREWOLF]: WinLoss,
   },
 };

--- a/src/components/Views/Setup/index.test.tsx
+++ b/src/components/Views/Setup/index.test.tsx
@@ -169,7 +169,7 @@ describe('<Setup />', () => {
       fireEvent.click(result.getByText('Start Game'));
 
       expect(mockVillageService.startGame).toHaveBeenCalledTimes(1);
-      expect(mockVillageService.startGame).toHaveBeenCalledWith(1, true, false);
+      expect(mockVillageService.startGame).toHaveBeenCalledWith(1, true, false, false);
     });
 
     describe('does not function when deck setup is incorrect', () => {

--- a/src/components/Views/Setup/index.test.tsx
+++ b/src/components/Views/Setup/index.test.tsx
@@ -169,7 +169,12 @@ describe('<Setup />', () => {
       fireEvent.click(result.getByText('Start Game'));
 
       expect(mockVillageService.startGame).toHaveBeenCalledTimes(1);
-      expect(mockVillageService.startGame).toHaveBeenCalledWith(1, true, false, false);
+      expect(mockVillageService.startGame).toHaveBeenCalledWith(
+        1,
+        true,
+        false,
+        false
+      );
     });
 
     describe('does not function when deck setup is incorrect', () => {

--- a/src/components/Views/Setup/index.tsx
+++ b/src/components/Views/Setup/index.tsx
@@ -31,7 +31,12 @@ export const Setup: React.FC<Props> = (props) => {
   const villageService = React.useContext(VillageServiceContext);
 
   const onClick = (): void => {
-    villageService.startGame(werewolvesCount, seerEnabled, bodyguardEnabled, lycanEnabled);
+    villageService.startGame(
+      werewolvesCount,
+      seerEnabled,
+      bodyguardEnabled,
+      lycanEnabled
+    );
   };
 
   if (!props.villageName || !props.lobbyId || !props.moderator) {

--- a/src/components/Views/Setup/index.tsx
+++ b/src/components/Views/Setup/index.tsx
@@ -27,10 +27,11 @@ export const Setup: React.FC<Props> = (props) => {
   const [werewolvesCount, setWerewolvesCount] = React.useState(0);
   const [seerEnabled, setSeerEnabled] = React.useState(true);
   const [bodyguardEnabled, setBodyguardEnabled] = React.useState(false);
+  const [lycanEnabled, setLycanEnabled] = React.useState(false);
   const villageService = React.useContext(VillageServiceContext);
 
   const onClick = (): void => {
-    villageService.startGame(werewolvesCount, seerEnabled, bodyguardEnabled);
+    villageService.startGame(werewolvesCount, seerEnabled, bodyguardEnabled, lycanEnabled);
   };
 
   if (!props.villageName || !props.lobbyId || !props.moderator) {
@@ -42,8 +43,9 @@ export const Setup: React.FC<Props> = (props) => {
 
   const bodyguardsCount = bodyguardEnabled ? 1 : 0;
   const seersCount = seerEnabled ? 1 : 0;
+  const lycansCount = lycanEnabled ? 1 : 0;
 
-  const goodCount = villagersCount + seersCount + bodyguardsCount;
+  const goodCount = villagersCount + seersCount + bodyguardsCount + lycansCount;
   const evilCount = werewolvesCount;
   const totalCount = goodCount + evilCount;
 
@@ -105,6 +107,15 @@ export const Setup: React.FC<Props> = (props) => {
             name='Bodyguards'
             checked={bodyguardEnabled}
             onChange={setBodyguardEnabled}
+          />
+        </div>
+
+        <div className={styles.flexTogether}>
+          <label htmlFor='Lycans'>Lycan:</label>
+          <CheckboxInput
+            name='Lycans'
+            checked={lycanEnabled}
+            onChange={setLycanEnabled}
           />
         </div>
       </div>

--- a/src/provider/Village/WebSocket/index.ts
+++ b/src/provider/Village/WebSocket/index.ts
@@ -147,7 +147,7 @@ export class WebSocketVillageProvider implements VillageProvider {
     } as JoinMessage);
   }
 
-  startGame({ werewolves, seer, bodyguard }: StartGameData): void {
+  startGame({ werewolves, seer, bodyguard, lycan }: StartGameData): void {
     this.sendSocketMessage({
       action: SOCKET_ACTIONS.START,
       data: {
@@ -155,6 +155,7 @@ export class WebSocketVillageProvider implements VillageProvider {
         werewolves,
         seer,
         bodyguard,
+        lycan,
       },
     } as StartMessage);
   }

--- a/src/provider/Village/types.ts
+++ b/src/provider/Village/types.ts
@@ -15,6 +15,7 @@ export interface StartGameData {
   werewolves: number;
   seer: boolean;
   bodyguard: boolean;
+  lycan: boolean;
 }
 
 export interface VoteData {

--- a/src/service/Village/index.ts
+++ b/src/service/Village/index.ts
@@ -6,7 +6,12 @@ import { logError } from '../../utils/logger';
 export interface AbstractVillageService {
   createVillage: (userName: string) => void;
   joinVillage: (userName: string, lobbyId: string) => void;
-  startGame: (werewolves: number, seer: boolean, bodyguard: boolean, lycan: boolean) => void;
+  startGame: (
+    werewolves: number,
+    seer: boolean,
+    bodyguard: boolean,
+    lycan: boolean
+  ) => void;
   werewolfVoteForPlayer: (playerName: string) => void;
   seerInspectPlayer: (playerName: string) => void;
   bodyguardSavePlayer: (playerName: string) => void;
@@ -53,7 +58,12 @@ export class VillageService implements AbstractVillageService {
     }
   }
 
-  startGame(werewolves: number, seer: boolean, bodyguard: boolean, lycan: boolean): void {
+  startGame(
+    werewolves: number,
+    seer: boolean,
+    bodyguard: boolean,
+    lycan: boolean
+  ): void {
     try {
       this.villageProvider.startGame({ werewolves, seer, bodyguard, lycan });
     } catch (error) {

--- a/src/service/Village/index.ts
+++ b/src/service/Village/index.ts
@@ -6,7 +6,7 @@ import { logError } from '../../utils/logger';
 export interface AbstractVillageService {
   createVillage: (userName: string) => void;
   joinVillage: (userName: string, lobbyId: string) => void;
-  startGame: (werewolves: number, seer: boolean, bodyguard: boolean) => void;
+  startGame: (werewolves: number, seer: boolean, bodyguard: boolean, lycan: boolean) => void;
   werewolfVoteForPlayer: (playerName: string) => void;
   seerInspectPlayer: (playerName: string) => void;
   bodyguardSavePlayer: (playerName: string) => void;
@@ -53,9 +53,9 @@ export class VillageService implements AbstractVillageService {
     }
   }
 
-  startGame(werewolves: number, seer: boolean, bodyguard: boolean): void {
+  startGame(werewolves: number, seer: boolean, bodyguard: boolean, lycan: boolean): void {
     try {
-      this.villageProvider.startGame({ werewolves, seer, bodyguard });
+      this.villageProvider.startGame({ werewolves, seer, bodyguard, lycan });
     } catch (error) {
       this.onError(error);
     }

--- a/src/types/player.ts
+++ b/src/types/player.ts
@@ -5,6 +5,7 @@ export enum PLAYER_ROLE {
   WEREWOLF = 'Werewolf',
   MODERATOR = 'Mod',
   BODYGUARD = 'Bodyguard',
+  LYCAN = 'Lycan',
 }
 
 export enum PLAYER_TEAM {


### PR DESCRIPTION
## ✅ What & Why

Added lycan role (already implemented on backend) to the client.

Changes include:

- Checkbox on the setup page to allow the mod to add the role to the game.
- Lycan role text to display to the player.
- Lycan phases defined (same as the villager in all cases).

## 🧪 Tests

- Updated test for setup stage to include Lycan flag.

## 📸 Screenshots

![image](https://user-images.githubusercontent.com/4058741/101990569-82642580-3c9f-11eb-9b2e-99357d13b014.png)

![image](https://user-images.githubusercontent.com/4058741/101990613-b8a1a500-3c9f-11eb-94a6-4b3b4db9e0c8.png)
