### PR TITLE
Add default views to simplify component matrix

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -4,11 +4,11 @@
 
 ## 🧪 Tests
 
-- [] Created/amended tests for any new/changed components
-- [] Created/amended tests for any new/changed functionality for the services
-- [] Created/amended tests for any new/changed functionality for the providers
-- [] Created/amended tests for any new/changed functionality for the Redux store
-- [] Created/amended tests for any new/changed functionality for utilities
+- [ ] Created/amended tests for any new/changed components
+- [ ] Created/amended tests for any new/changed functionality for the services
+- [ ] Created/amended tests for any new/changed functionality for the providers
+- [ ] Created/amended tests for any new/changed functionality for the Redux store
+- [ ] Created/amended tests for any new/changed functionality for utilities
 
 <!-- Ensure you've covered what's required. Put an "x" between the square brackets to fill in the checkbox -->
 

--- a/src/components/ViewController/index.tsx
+++ b/src/components/ViewController/index.tsx
@@ -31,12 +31,13 @@ export const ViewController: React.FC<Props> = (props) => {
   }
 
   const MatrixComponent =
-    COMPONENT_MATRIX[props.phaseName][props.self.attributes.role];
+    COMPONENT_MATRIX[props.phaseName][props.self.attributes.role] ||
+    COMPONENT_MATRIX[props.phaseName].default;
 
   if (!MatrixComponent) {
     logError(
       new Error(
-        `No component found for phase ${props.phaseName} with role ${props.self?.attributes.role}`
+        `No component found for phase ${props.phaseName} with role ${props.self?.attributes.role}, and no default set`
       )
     );
     return null;

--- a/src/components/ViewController/matrix.ts
+++ b/src/components/ViewController/matrix.ts
@@ -15,51 +15,30 @@ import WinLoss from '../Views/WinLoss';
 
 export const COMPONENT_MATRIX: {
   [key in PHASE_NAME]: {
-    [key in PLAYER_ROLE]?: React.FC<{}>;
+    [key in PLAYER_ROLE | 'default']?: React.FC<{}>;
   };
 } = {
   [PHASE_NAME.LOBBY]: {
     [PLAYER_ROLE.MODERATOR]: Setup,
-    [PLAYER_ROLE.UNKNOWN]: WaitingForStartTextOnly,
+    default: WaitingForStartTextOnly,
   },
   [PHASE_NAME.DAY]: {
-    [PLAYER_ROLE.BODYGUARD]: DaytimeTextOnly,
     [PLAYER_ROLE.MODERATOR]: LynchPickSinglePlayer,
-    [PLAYER_ROLE.SEER]: DaytimeTextOnly,
-    [PLAYER_ROLE.VILLAGER]: DaytimeTextOnly,
-    [PLAYER_ROLE.LYCAN]: DaytimeTextOnly,
-    [PLAYER_ROLE.WEREWOLF]: DaytimeTextOnly,
+    default: DaytimeTextOnly,
   },
   [PHASE_NAME.SEER]: {
-    [PLAYER_ROLE.BODYGUARD]: NonSeerTextOnly,
-    [PLAYER_ROLE.MODERATOR]: NonSeerTextOnly,
     [PLAYER_ROLE.SEER]: SeerPickSinglePlayer,
-    [PLAYER_ROLE.VILLAGER]: NonSeerTextOnly,
-    [PLAYER_ROLE.LYCAN]: NonSeerTextOnly,
-    [PLAYER_ROLE.WEREWOLF]: NonSeerTextOnly,
+    default: NonSeerTextOnly,
   },
   [PHASE_NAME.BODYGUARD]: {
     [PLAYER_ROLE.BODYGUARD]: BodyguardPickSinglePlayer,
-    [PLAYER_ROLE.MODERATOR]: NonBodyguardTextOnly,
-    [PLAYER_ROLE.SEER]: NonBodyguardTextOnly,
-    [PLAYER_ROLE.VILLAGER]: NonBodyguardTextOnly,
-    [PLAYER_ROLE.LYCAN]: NonBodyguardTextOnly,
-    [PLAYER_ROLE.WEREWOLF]: NonBodyguardTextOnly,
+    default: NonBodyguardTextOnly,
   },
   [PHASE_NAME.WEREWOLF]: {
-    [PLAYER_ROLE.BODYGUARD]: NonWerewolfTextOnly,
-    [PLAYER_ROLE.MODERATOR]: NonWerewolfTextOnly,
-    [PLAYER_ROLE.SEER]: NonWerewolfTextOnly,
-    [PLAYER_ROLE.VILLAGER]: NonWerewolfTextOnly,
-    [PLAYER_ROLE.LYCAN]: NonWerewolfTextOnly,
     [PLAYER_ROLE.WEREWOLF]: WerewolfVoteSinglePlayer,
+    default: NonWerewolfTextOnly,
   },
   [PHASE_NAME.END]: {
-    [PLAYER_ROLE.BODYGUARD]: WinLoss,
-    [PLAYER_ROLE.MODERATOR]: WinLoss,
-    [PLAYER_ROLE.SEER]: WinLoss,
-    [PLAYER_ROLE.VILLAGER]: WinLoss,
-    [PLAYER_ROLE.LYCAN]: WinLoss,
-    [PLAYER_ROLE.WEREWOLF]: WinLoss,
+    default: WinLoss,
   },
 };


### PR DESCRIPTION
## ✅ What & Why

As suggested [here](https://github.com/ripixel/janky-werewolf-client/pull/44#discussion_r541685557):

> Seems a lot of the time there is one role that will get a different view for a given phase to the other roles. Wondering if we can make this less verbose by providing a default/fallback view for each phase to avoid having to define the same thing for lots of roles?

<!--- High level description of changes. Highlight expectations for code review. --->

## 🧪 Tests

- [x] Created/amended tests for any new/changed components
- [x] Created/amended tests for any new/changed functionality for the services
- [x] Created/amended tests for any new/changed functionality for the providers
- [x] Created/amended tests for any new/changed functionality for the Redux store
- [x] Created/amended tests for any new/changed functionality for utilities

<!-- Ensure you've covered what's required. Put an "x" between the square brackets to fill in the checkbox -->

## 📸 Screenshots

No UI changes

<!--- Any necessary screenshots. If it's a UI change, there should be something here --->

## 📓 Notes

<!--- Anything else you may want to talk about/get feedback on relative to this work --->
