### PR TITLE
Make player name optional for seer request and enable skip button for…

### DIFF
--- a/src/components/Views/PickSinglePlayer/Seer/index.test.tsx
+++ b/src/components/Views/PickSinglePlayer/Seer/index.test.tsx
@@ -52,7 +52,7 @@ describe('Components > Views > PickSinglePlayer > Seer', () => {
     expect(result.getByText('alex')).toBeInTheDocument();
   });
 
-  it('handles clicking on a player correclty', () => {
+  it('handles clicking on a player correctly', () => {
     const mockVillageService = {
       seerInspectPlayer: jest.fn(),
     } as any;
@@ -67,6 +67,23 @@ describe('Components > Views > PickSinglePlayer > Seer', () => {
 
     expect(mockVillageService.seerInspectPlayer).toHaveBeenCalledTimes(1);
     expect(mockVillageService.seerInspectPlayer).toHaveBeenCalledWith('alex');
+  });
+
+  it('handles clicking on skip correctly', () => {
+    const mockVillageService = {
+      seerInspectPlayer: jest.fn(),
+    } as any;
+
+    const result = render(
+      <VillageServiceContextProvider value={mockVillageService}>
+        <SeerPickSinglePlayer {...baseProps} />
+      </VillageServiceContextProvider>
+    );
+
+    fireEvent.click(result.getByText('Skip checking a player'));
+
+    expect(mockVillageService.seerInspectPlayer).toHaveBeenCalledTimes(1);
+    expect(mockVillageService.seerInspectPlayer).toHaveBeenCalledWith();
   });
 
   describe('mapStateToProps', () => {

--- a/src/components/Views/PickSinglePlayer/Seer/index.tsx
+++ b/src/components/Views/PickSinglePlayer/Seer/index.tsx
@@ -27,6 +27,8 @@ export const SeerPickSinglePlayer: React.FC<Props> = ({ players }) => {
       onPlayerPick={(playerName: string): void =>
         villageService.seerInspectPlayer(playerName)
       }
+      skipPlayerPickText='Skip checking a player'
+      onSkipPlayerPick={(): void => villageService.seerInspectPlayer()}
     />
   );
 };

--- a/src/provider/Village/WebSocket/index.ts
+++ b/src/provider/Village/WebSocket/index.ts
@@ -6,6 +6,7 @@ import {
   JoinVillageData,
   StartGameData,
   VoteData,
+  SeerData,
 } from '../types';
 import { AbstractStoreInteractorService } from '../../../service/StoreInteractor';
 import { Phases } from '../../../types/phase';
@@ -170,7 +171,7 @@ export class WebSocketVillageProvider implements VillageProvider {
     } as Werewolf);
   }
 
-  seerInspectPlayer({ playerName }: VoteData): void {
+  seerInspectPlayer({ playerName }: SeerData): void {
     this.sendSocketMessage({
       action: SOCKET_ACTIONS.SEER,
       data: {

--- a/src/provider/Village/types.ts
+++ b/src/provider/Village/types.ts
@@ -22,13 +22,17 @@ export interface VoteData {
   playerName: string;
 }
 
+export interface SeerData {
+  playerName?: string;
+}
+
 export interface VillageProvider {
   setInteractor: (interactor: AbstractStoreInteractorService) => void;
   createVillage: (createVillageData: CreateVillageData) => void;
   joinVillage: (joinVillageData: JoinVillageData) => void;
   startGame: (startGameData: StartGameData) => void;
   werewolfVoteForPlayer: (voteData: VoteData) => void;
-  seerInspectPlayer: (voteData: VoteData) => void;
+  seerInspectPlayer: (voteData: SeerData) => void;
   bodyguardSavePlayer: (voteData: VoteData) => void;
   lynchPlayer: (voteData: VoteData) => void;
   sleepNow: () => void;

--- a/src/service/Village/index.ts
+++ b/src/service/Village/index.ts
@@ -71,7 +71,7 @@ export class VillageService implements AbstractVillageService {
     });
   }
 
-  seerInspectPlayer(playerName: string): void {
+  seerInspectPlayer(playerName?: string): void {
     this.runSafe(() => {
       this.villageProvider.seerInspectPlayer({ playerName });
     });


### PR DESCRIPTION
## ✅ What & Why

Enable the seer to skip choosing a player during their phase. This is to avoid the situation where the seer has checked all living players and the game gets stuck during that phase. Other options such as skipping the seer stage on the backend would be possible but are less true to the original game.

## 🧪 Tests

- New test for seer skipping calling to the service provider.

## 📓 Notes

Change to support this (optional parameter on the seer call) is already live on the backend.
