### PR TITLE
No alert notification

### DIFF
--- a/src/components/Alerts/index.test.tsx
+++ b/src/components/Alerts/index.test.tsx
@@ -1,0 +1,160 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import React from 'react';
+import '@testing-library/jest-dom/extend-expect';
+import { render } from '@testing-library/react';
+
+import { getPhaseName, getUnreadAlerts } from '../../store/connectorHelpers';
+import { dismissAlert } from '../../store/actions/game';
+
+import { Alerts, mapDispatchToProps, mapStateToProps } from '.';
+import { PHASE_NAME } from '../../types/phase';
+import { ALERT_ICON } from '../../store/reducers/game';
+
+jest.mock('../../store/connectorHelpers', () => ({
+  getPhaseName: jest.fn((): string => 'phase-name'),
+  getUnreadAlerts: jest.fn((): string => 'unread-alerts'),
+}));
+
+jest.mock('../../store/actions/game');
+
+describe('Components > Alerts', () => {
+  const mockAlert = {
+    title: 'Test Title',
+    content: 'Test Content',
+    icon: ALERT_ICON.DEATH,
+    subject: 'Dave',
+    id: 'test-id',
+  };
+
+  describe('renders null', () => {
+    describe('with no alerts passed', () => {
+      it('when alerts array is undefined', () => {
+        const result = render(
+          <Alerts phase={PHASE_NAME.DAY} dismissAlert={jest.fn()} />
+        );
+
+        expect(result.container).toBeEmptyDOMElement();
+      });
+      it('when alerts array has no members', () => {
+        const result = render(
+          <Alerts phase={PHASE_NAME.DAY} alerts={[]} dismissAlert={jest.fn()} />
+        );
+
+        expect(result.container).toBeEmptyDOMElement();
+      });
+    });
+
+    it('when phase is LOBBY', () => {
+      const result = render(
+        <Alerts
+          phase={PHASE_NAME.LOBBY}
+          alerts={[mockAlert]}
+          dismissAlert={jest.fn()}
+        />
+      );
+
+      expect(result.container).toBeEmptyDOMElement();
+    });
+
+    it('when phase is END', () => {
+      const result = render(
+        <Alerts
+          phase={PHASE_NAME.END}
+          alerts={[mockAlert]}
+          dismissAlert={jest.fn()}
+        />
+      );
+
+      expect(result.container).toBeEmptyDOMElement();
+    });
+  });
+
+  describe('renders as expected', () => {
+    it('with one alert', () => {
+      const result = render(
+        <Alerts
+          phase={PHASE_NAME.DAY}
+          alerts={[mockAlert]}
+          dismissAlert={jest.fn()}
+        />
+      );
+
+      expect(result.getByText('Test Title')).toBeInTheDocument();
+      expect(result.getByText('Test Content')).toBeInTheDocument();
+      expect(result.getByText('DEATH')).toBeInTheDocument();
+      expect(result.getByText('Dismiss')).toBeInTheDocument();
+      expect(() => result.getByText('0 Unread Alerts')).toThrow();
+    });
+
+    it('with multiple alerts', () => {
+      const result = render(
+        <Alerts
+          phase={PHASE_NAME.DAY}
+          alerts={[mockAlert, mockAlert]}
+          dismissAlert={jest.fn()}
+        />
+      );
+
+      expect(result.getByText('Test Title')).toBeInTheDocument();
+      expect(result.getByText('Test Content')).toBeInTheDocument();
+      expect(result.getByText('DEATH')).toBeInTheDocument();
+      expect(result.getByText('Dismiss')).toBeInTheDocument();
+      expect(result.getByText('1 Unread Alerts')).toBeInTheDocument();
+    });
+  });
+
+  describe('interactions', () => {
+    it('clicking the Dismiss button functions as expected', () => {
+      const mockDismissAlert = jest.fn();
+
+      const result = render(
+        <Alerts
+          phase={PHASE_NAME.DAY}
+          alerts={[mockAlert]}
+          dismissAlert={mockDismissAlert}
+        />
+      );
+
+      result.getByText('Dismiss').click();
+
+      expect(mockDismissAlert).toHaveBeenCalledTimes(1);
+      expect(mockDismissAlert).toHaveBeenCalledWith('test-id');
+    });
+  });
+
+  describe('mapStateToProps', () => {
+    it('returns correct props', () => {
+      const mockState = {
+        some: 'mock-state',
+      } as any;
+
+      const result = mapStateToProps(mockState);
+
+      expect(getPhaseName).toHaveBeenCalledTimes(1);
+      expect(getPhaseName).toHaveBeenCalledWith(mockState);
+      expect(getUnreadAlerts).toHaveBeenCalledTimes(1);
+      expect(getUnreadAlerts).toHaveBeenCalledWith(mockState);
+
+      expect(result).toEqual({
+        phase: 'phase-name',
+        alerts: 'unread-alerts',
+      });
+    });
+  });
+
+  describe('mapDispatchToProps', () => {
+    it('returns correct props', () => {
+      const mockDispatch = jest.fn();
+
+      const result = mapDispatchToProps(mockDispatch);
+
+      expect(result).toEqual({
+        dismissAlert: expect.any(Function),
+      });
+
+      result.dismissAlert('123');
+      expect(dismissAlert).toHaveBeenCalledTimes(1);
+      expect(dismissAlert).toHaveBeenCalledWith('123');
+    });
+  });
+});

--- a/src/components/Alerts/index.tsx
+++ b/src/components/Alerts/index.tsx
@@ -1,0 +1,66 @@
+import React from 'react';
+import { connect } from 'react-redux';
+import { Dispatch } from 'redux';
+import { dismissAlert, DismissAlertAction } from '../../store/actions/game';
+import { getPhaseName, getUnreadAlerts } from '../../store/connectorHelpers';
+
+import { State } from '../../store/reducers';
+import { Alert } from '../../store/reducers/game';
+import { PHASE_NAME } from '../../types/phase';
+import Button from '../Button';
+
+import styles from './styles.scss';
+
+interface Props {
+  phase?: PHASE_NAME;
+  alerts?: Alert[];
+  dismissAlert: (id: string) => DismissAlertAction;
+}
+
+export const Alerts: React.FC<Props> = ({ alerts, phase, dismissAlert }) => {
+  if (
+    !alerts ||
+    alerts.length === 0 ||
+    phase === PHASE_NAME.LOBBY ||
+    phase === PHASE_NAME.END
+  ) {
+    return null;
+  }
+
+  const alert = (
+    <React.Fragment>
+      <p>{alerts[0].title}</p>
+      <p>{alerts[0].content}</p>
+      <p className={styles.alertIcon}>{alerts[0].icon}</p>
+      <Button onClick={(): DismissAlertAction => dismissAlert(alerts[0].id)}>
+        Dismiss
+      </Button>
+    </React.Fragment>
+  );
+
+  const remainingAlerts = alerts.length - 1;
+
+  return alert ? (
+    <div className={styles.alert}>
+      {alert}
+      {remainingAlerts > 0 && (
+        <p className={styles.remainingAlerts}>
+          {remainingAlerts} Unread Alerts
+        </p>
+      )}
+    </div>
+  ) : null;
+};
+
+export const mapStateToProps = (state: State): Omit<Props, 'dismissAlert'> => ({
+  phase: getPhaseName(state),
+  alerts: getUnreadAlerts(state),
+});
+
+export const mapDispatchToProps = (
+  dispatch: Dispatch
+): Pick<Props, 'dismissAlert'> => ({
+  dismissAlert: (id: string): DismissAlertAction => dispatch(dismissAlert(id)),
+});
+
+export default connect(mapStateToProps, mapDispatchToProps)(Alerts);

--- a/src/components/Alerts/styles.scss
+++ b/src/components/Alerts/styles.scss
@@ -1,0 +1,15 @@
+.alert {
+  background: white;
+  color: #333;
+  padding: 1rem;
+  margin-bottom: 1rem;
+
+  .remainingAlerts {
+    color: red;
+    margin-bottom: 0;
+  }
+}
+
+.alertIcon {
+  display: none;
+}

--- a/src/components/Alerts/styles.scss.d.ts
+++ b/src/components/Alerts/styles.scss.d.ts
@@ -1,0 +1,7 @@
+declare const styles: {
+  readonly "alert": string;
+  readonly "alertIcon": string;
+  readonly "remainingAlerts": string;
+};
+export = styles;
+

--- a/src/components/App/index.test.tsx
+++ b/src/components/App/index.test.tsx
@@ -1,12 +1,15 @@
 /* eslint-disable @typescript-eslint/no-explicit-any, @typescript-eslint/no-unused-vars, react/display-name */
 import React from 'react';
 import '@testing-library/jest-dom/extend-expect';
+import { render } from '@testing-library/react';
 
 import App from '.';
-import { render } from '@testing-library/react';
 
 // Mock components with a testids
 jest.mock('../../store', () => 'storemock');
+jest.mock('../Alerts', () => (): JSX.Element => {
+  return <div data-testid='alerts' />;
+});
 jest.mock('../Layout', () => (props: any): JSX.Element => {
   return <div data-testid='layout'>{props.children}</div>;
 });
@@ -49,6 +52,7 @@ describe('Components > App', () => {
       'initVillageServiceContextReturn'
     );
     expect(result.getByTestId('layout')).toBeInTheDocument();
+    expect(result.getByTestId('alerts')).toBeInTheDocument();
     expect(result.getByTestId('viewcontroller')).toBeInTheDocument();
     expect(result.getByTestId('reduxprovider')).toBeInTheDocument();
     expect(result.getByTestId('reduxprovider')).toHaveAttribute(

--- a/src/components/App/index.tsx
+++ b/src/components/App/index.tsx
@@ -8,6 +8,7 @@ import {
   initVillageServiceContext,
 } from '../../context/VillageService';
 import ViewController from '../ViewController';
+import Alerts from '../Alerts';
 
 import './reset.scss';
 import './styles.scss';
@@ -16,6 +17,7 @@ export const App: React.FC = () => (
   <VillageServiceContextProvider value={initVillageServiceContext()}>
     <ReduxProvider store={store}>
       <Layout>
+        <Alerts />
         <ViewController />
       </Layout>
     </ReduxProvider>

--- a/src/components/PlayerWrapper/copy.test.ts
+++ b/src/components/PlayerWrapper/copy.test.ts
@@ -1,0 +1,21 @@
+import { PLAYER_ROLE, PLAYER_TEAM } from '../../types/player';
+
+import { TEAM_TEXT, ROLE_TEXT } from './copy';
+
+describe('Components > PlayerWrapper > Copy', () => {
+  describe('TEAM_TEXT', () => {
+    it('has a defined value for each team', () => {
+      Object.values(PLAYER_TEAM).forEach((team) => {
+        expect(TEAM_TEXT[team]).not.toBeUndefined();
+      });
+    });
+  });
+
+  describe('ROLE_TEXT', () => {
+    it('has a defined value for every role', () => {
+      Object.values(PLAYER_ROLE).forEach((role) => {
+        expect(ROLE_TEXT[role]).not.toBeUndefined();
+      });
+    });
+  });
+});

--- a/src/components/PlayerWrapper/copy.ts
+++ b/src/components/PlayerWrapper/copy.ts
@@ -1,0 +1,25 @@
+import { PLAYER_ROLE, PLAYER_TEAM } from '../../types/player';
+
+export const ROLE_TEXT = {
+  [PLAYER_ROLE.VILLAGER]: 'No special powers',
+  [PLAYER_ROLE.SEER]:
+    "Each night, choose someone and find out if they're good or evil.",
+  [PLAYER_ROLE.BODYGUARD]:
+    'Each night, choose someone to protect. If the werewolves try to kill them, they will be saved. You cannot guard the same person on consecutive nights.',
+  [PLAYER_ROLE.WEREWOLF]:
+    'Each night, choose someone to kill. All werewolves must agree.',
+  [PLAYER_ROLE.MODERATOR]:
+    "You are running the game! Do your talking and explain what's happening.",
+  [PLAYER_ROLE.LYCAN]:
+    'No special powers but you will appear to the seer as a werewolf.',
+  [PLAYER_ROLE.UNKNOWN]:
+    'You should never see this. If you do, tell James/Mike',
+};
+
+export const TEAM_TEXT = {
+  [PLAYER_TEAM.EVIL]:
+    'You win when the number of good players is equal to or less than the number of werewolves alive',
+  [PLAYER_TEAM.GOOD]: 'You win when all the evil players are dead',
+  [PLAYER_TEAM.UNKNOWN]:
+    'You should never see this. If you do, tell James/Mike',
+};

--- a/src/components/PlayerWrapper/index.test.tsx
+++ b/src/components/PlayerWrapper/index.test.tsx
@@ -8,11 +8,10 @@ import { PHASE_NAME } from '../../types/phase';
 import {
   getPhaseName,
   getPlayersWithoutRole,
-  getOldPlayersWithoutRole,
   getSelf,
 } from '../../store/connectorHelpers';
 
-import { alertOnPlayerStateChanges, mapStateToProps, PlayerWrapper } from '.';
+import { mapStateToProps, PlayerWrapper } from '.';
 
 jest.mock('../../store/connectorHelpers', () => ({
   getPhaseName: jest.fn((): string => 'phase-name'),
@@ -25,13 +24,7 @@ describe('Components > PlayerWrapper', () => {
   describe('renders as expected', () => {
     it('throws an error if no self given', () => {
       expect(() =>
-        render(
-          <PlayerWrapper
-            players={[]}
-            oldPlayers={[]}
-            phaseName={PHASE_NAME.LOBBY}
-          />
-        )
+        render(<PlayerWrapper players={[]} phaseName={PHASE_NAME.LOBBY} />)
       ).toThrow('No game yet initialised!');
     });
 
@@ -40,7 +33,6 @@ describe('Components > PlayerWrapper', () => {
         render(
           <PlayerWrapper
             players={[]}
-            oldPlayers={[]}
             self={{
               attributes: {
                 alive: true,
@@ -58,7 +50,6 @@ describe('Components > PlayerWrapper', () => {
       const result = render(
         <PlayerWrapper
           players={[]}
-          oldPlayers={[]}
           self={{
             attributes: {
               alive: true,
@@ -79,7 +70,6 @@ describe('Components > PlayerWrapper', () => {
       const result = render(
         <PlayerWrapper
           players={[]}
-          oldPlayers={[]}
           self={{
             attributes: {
               alive: true,
@@ -101,7 +91,6 @@ describe('Components > PlayerWrapper', () => {
       const result = render(
         <PlayerWrapper
           players={[]}
-          oldPlayers={[]}
           self={{
             attributes: {
               alive: false,
@@ -126,7 +115,6 @@ describe('Components > PlayerWrapper', () => {
       const result = render(
         <PlayerWrapper
           players={[]}
-          oldPlayers={[]}
           self={{
             attributes: {
               alive: true,
@@ -150,16 +138,6 @@ describe('Components > PlayerWrapper', () => {
       const result = render(
         <PlayerWrapper
           players={[
-            {
-              attributes: {
-                alive: true,
-                role: PLAYER_ROLE.BODYGUARD,
-                team: PLAYER_TEAM.GOOD,
-              },
-              name: 'dave',
-            },
-          ]}
-          oldPlayers={[
             {
               attributes: {
                 alive: true,
@@ -209,133 +187,14 @@ describe('Components > PlayerWrapper', () => {
         PLAYER_ROLE.MODERATOR,
         true
       );
-      expect(getOldPlayersWithoutRole).toHaveBeenCalledTimes(1);
-      expect(getOldPlayersWithoutRole).toHaveBeenCalledWith(
-        mockState,
-        PLAYER_ROLE.MODERATOR,
-        true
-      );
       expect(getPhaseName).toHaveBeenCalledTimes(1);
       expect(getPhaseName).toHaveBeenCalledWith(mockState);
 
       expect(result).toEqual({
         self: 'self',
         players: 'players-without-role',
-        oldPlayers: 'old-players-without-role',
         phaseName: 'phase-name',
       });
-    });
-  });
-
-  describe('alertOnPlayerStateChanges', () => {
-    let alertSpy: jest.SpyInstance;
-
-    beforeEach(() => {
-      jest.resetAllMocks();
-      alertSpy = jest.spyOn(window, 'alert');
-    });
-
-    it('does not alert when no changes', () => {
-      const oldPlayers = [
-        {
-          name: 'dave',
-          attributes: {
-            role: PLAYER_ROLE.UNKNOWN,
-            team: PLAYER_TEAM.UNKNOWN,
-            alive: true,
-          },
-        },
-      ];
-      const newPlayers = [
-        {
-          name: 'dave',
-          attributes: {
-            role: PLAYER_ROLE.UNKNOWN,
-            team: PLAYER_TEAM.UNKNOWN,
-            alive: true,
-          },
-        },
-      ];
-
-      alertOnPlayerStateChanges(oldPlayers, newPlayers);
-
-      expect(alertSpy).toHaveBeenCalledTimes(0);
-    });
-
-    it('alerts changes about death', () => {
-      const oldPlayers = [
-        {
-          name: 'dave',
-          attributes: {
-            role: PLAYER_ROLE.UNKNOWN,
-            team: PLAYER_TEAM.UNKNOWN,
-            alive: true,
-          },
-        },
-        {
-          name: 'tom',
-          attributes: {
-            role: PLAYER_ROLE.UNKNOWN,
-            team: PLAYER_TEAM.UNKNOWN,
-            alive: true,
-          },
-        },
-      ];
-      const newPlayers = [
-        {
-          name: 'dave',
-          attributes: {
-            role: PLAYER_ROLE.BODYGUARD,
-            team: PLAYER_TEAM.GOOD,
-            alive: false,
-          },
-        },
-      ];
-
-      alertOnPlayerStateChanges(oldPlayers, newPlayers);
-
-      expect(alertSpy).toHaveBeenCalledTimes(1);
-      expect(alertSpy).toHaveBeenCalledWith(
-        'dave is now dead! They were a Bodyguard.'
-      );
-    });
-
-    it('alerts changes about team revealing', () => {
-      const oldPlayers = [
-        {
-          name: 'dave',
-          attributes: {
-            role: PLAYER_ROLE.UNKNOWN,
-            team: PLAYER_TEAM.UNKNOWN,
-            alive: true,
-          },
-        },
-        {
-          name: 'tom',
-          attributes: {
-            role: PLAYER_ROLE.UNKNOWN,
-            team: PLAYER_TEAM.UNKNOWN,
-            alive: true,
-          },
-        },
-      ];
-      const newPlayers = [
-        {
-          name: 'dave',
-          attributes: {
-            role: PLAYER_ROLE.BODYGUARD,
-            team: PLAYER_TEAM.GOOD,
-            alive: true,
-          },
-        },
-      ];
-
-      alertOnPlayerStateChanges(oldPlayers, newPlayers);
-
-      expect(alertSpy).toHaveBeenCalledTimes(1);
-      expect(alertSpy).toHaveBeenCalledWith(
-        '[ONLY TO YOU] You now know that dave is Good.'
-      );
     });
   });
 });

--- a/src/components/PlayerWrapper/index.tsx
+++ b/src/components/PlayerWrapper/index.tsx
@@ -1,98 +1,29 @@
 import React from 'react';
 import classnames from 'classnames';
+import { connect } from 'react-redux';
 
 import { PLAYER_ROLE, PLAYER_TEAM, Player } from '../../types/player';
-
-import styles from './styles.scss';
 import { PHASE_NAME } from '../../types/phase';
-import { connect } from 'react-redux';
 import { State } from '../../store/reducers';
 import {
-  getOldPlayersWithoutRole,
   getPhaseName,
   getPlayersWithoutRole,
   getSelf,
 } from '../../store/connectorHelpers';
+import { ROLE_TEXT, TEAM_TEXT } from './copy';
+
+import styles from './styles.scss';
 
 interface Props {
   self?: Player;
   players: Player[];
-  oldPlayers: Player[];
   phaseName?: PHASE_NAME;
 }
 
-const ROLE_TEXT = {
-  [PLAYER_ROLE.VILLAGER]: 'No special powers',
-  [PLAYER_ROLE.SEER]:
-    "Each night, choose someone and find out if they're good or evil.",
-  [PLAYER_ROLE.BODYGUARD]:
-    'Each night, choose someone to protect. If the werewolves try to kill them, they will be saved. You cannot guard the same person on consecutive nights.',
-  [PLAYER_ROLE.WEREWOLF]:
-    'Each night, choose someone to kill. All werewolves must agree.',
-  [PLAYER_ROLE.MODERATOR]:
-    "You are running the game! Do your talking and explain what's happening.",
-  [PLAYER_ROLE.LYCAN]:
-    'No special powers but you will appear to the seer as a werewolf.',
-  [PLAYER_ROLE.UNKNOWN]:
-    'You should never see this. If you do, tell James/Mike',
-};
-
-const TEAM_TEXT = {
-  [PLAYER_TEAM.EVIL]:
-    'You win when the number of good players is equal to or less than the number of werewolves alive',
-  [PLAYER_TEAM.GOOD]: 'You win when all the evil players are dead',
-  [PLAYER_TEAM.UNKNOWN]:
-    'You should never see this. If you do, tell James/Mike',
-};
-
-export const alertOnPlayerStateChanges = (
-  oldPlayers: Player[],
-  newPlayers: Player[]
-): void => {
-  if (oldPlayers.length === 0) {
-    return;
-  }
-
-  const changes: string[] = [];
-
-  oldPlayers.forEach((oldPlayer) => {
-    const newPlayer = newPlayers.find(
-      (player) => player.name === oldPlayer.name
-    );
-
-    if (!newPlayer) {
-      return;
-    }
-
-    if (newPlayer.attributes.alive !== oldPlayer.attributes.alive) {
-      changes.push(
-        `${newPlayer.name} is now dead! They were a ${newPlayer.attributes.role}.`
-      );
-    } else if (newPlayer.attributes.team !== oldPlayer.attributes.team) {
-      changes.push(
-        `[ONLY TO YOU] You now know that ${newPlayer.name} is ${newPlayer.attributes.team}.`
-      );
-    }
-  });
-
-  if (changes.length > 0) {
-    alert(changes.join('\n'));
-  }
-};
-
 export const PlayerWrapper: React.FC<Props> = (props) => {
-  /**
-   * This section is a dirty, dirty hack - but it will do for a quick and easy last-changed alert
-   */
-
   if (!props.self || !props.phaseName) {
     throw new Error('No game yet initialised!');
   }
-
-  if (props.self.attributes.role !== PLAYER_ROLE.MODERATOR) {
-    alertOnPlayerStateChanges(props.oldPlayers, props.players);
-  }
-
   let aliveStatus = '';
   if (props.self.attributes.role !== PLAYER_ROLE.MODERATOR) {
     aliveStatus = props.self.attributes.alive ? ' - Alive' : ' - Dead';
@@ -164,7 +95,6 @@ export const PlayerWrapper: React.FC<Props> = (props) => {
 export const mapStateToProps = (state: State): Props => ({
   self: getSelf(state),
   players: getPlayersWithoutRole(state, PLAYER_ROLE.MODERATOR, true),
-  oldPlayers: getOldPlayersWithoutRole(state, PLAYER_ROLE.MODERATOR, true),
   phaseName: getPhaseName(state),
 });
 

--- a/src/provider/Village/WebSocket/index.ts
+++ b/src/provider/Village/WebSocket/index.ts
@@ -10,7 +10,6 @@ import {
 import { AbstractStoreInteractorService } from '../../../service/StoreInteractor';
 import { Phases } from '../../../types/phase';
 import { Player, PLAYER_ROLE, PLAYER_TEAM } from '../../../types/player';
-import { GameState } from '../../../store/reducers/game';
 
 enum SOCKET_ACTIONS {
   JOIN = 'join',
@@ -107,6 +106,12 @@ export interface MessageGameState {
     phase: Phases;
     players: Player[];
   };
+}
+export interface GameStateFromSocket {
+  lobbyId: string; // the game join code used
+  villageName: string;
+  players: Player[];
+  phase: Phases;
 }
 
 export class WebSocketVillageProvider implements VillageProvider {
@@ -257,7 +262,7 @@ export class WebSocketVillageProvider implements VillageProvider {
 
   private transformSocketGameStateToLocal({
     game_state,
-  }: MessageGameState): GameState {
+  }: MessageGameState): GameStateFromSocket {
     game_state.players.forEach(
       (player) =>
         (player.attributes = player.attributes

--- a/src/service/StoreInteractor/index.ts
+++ b/src/service/StoreInteractor/index.ts
@@ -1,15 +1,15 @@
 import { Store } from 'redux';
 
 import { State } from '../../store/reducers';
-import { GameState } from '../../store/reducers/game';
 import { initGame, updateGame } from '../../store/actions/game';
 import { Action } from '../../store/actions/types';
 import { UserState } from '../../store/reducers/user';
 import { setName } from '../../store/actions/user';
+import { GameStateFromSocket } from '../../provider/Village/WebSocket';
 
 export interface AbstractStoreInteractorService {
-  initGame: (gameState: GameState) => void;
-  updateGame: (gameState: GameState) => void;
+  initGame: (gameState: GameStateFromSocket) => void;
+  updateGame: (gameState: GameStateFromSocket) => void;
   setUserName: (name: string) => void;
   getUser: () => UserState;
 }
@@ -21,11 +21,11 @@ export class StoreInteractorService implements AbstractStoreInteractorService {
     this.store = store;
   }
 
-  initGame(gameState: GameState): void {
+  initGame(gameState: GameStateFromSocket): void {
     this.store.dispatch(initGame(gameState));
   }
 
-  updateGame(gameState: GameState): void {
+  updateGame(gameState: GameStateFromSocket): void {
     this.store.dispatch(updateGame(gameState));
   }
 

--- a/src/store/actions/game/index.test.ts
+++ b/src/store/actions/game/index.test.ts
@@ -1,10 +1,10 @@
-import { GameState } from '../../reducers/game';
 import { PHASE_NAME } from '../../../types/phase';
-import { initGame, updateGame, GAME_ACTION_TYPES } from '.';
+import { initGame, updateGame, GAME_ACTION_TYPES, dismissAlert } from '.';
+import { GameStateFromSocket } from '../../../provider/Village/WebSocket';
 
 describe('Store > Actions > Game', () => {
   describe('initGame', () => {
-    const mockGameState: GameState = {
+    const mockGameState: GameStateFromSocket = {
       lobbyId: '12test34',
       phase: {
         name: PHASE_NAME.LOBBY,
@@ -23,7 +23,7 @@ describe('Store > Actions > Game', () => {
   });
 
   describe('updateGame', () => {
-    const mockGameState: GameState = {
+    const mockGameState: GameStateFromSocket = {
       lobbyId: '12test34',
       phase: {
         name: PHASE_NAME.LOBBY,
@@ -37,6 +37,17 @@ describe('Store > Actions > Game', () => {
       expect(updateGame(mockGameState)).toEqual({
         type: GAME_ACTION_TYPES.UPDATE_GAME,
         payload: { ...mockGameState },
+      });
+    });
+  });
+
+  describe('dismissAlert', () => {
+    it('returns as expected', () => {
+      expect(dismissAlert('test-id')).toEqual({
+        type: GAME_ACTION_TYPES.DISMISS_ALERT,
+        payload: {
+          alertId: 'test-id',
+        },
       });
     });
   });

--- a/src/store/actions/game/index.ts
+++ b/src/store/actions/game/index.ts
@@ -1,19 +1,28 @@
-import { GameState } from '../../reducers/game';
+import { GameStateFromSocket } from '../../../provider/Village/WebSocket';
 import { Action } from '../types';
 
 export enum GAME_ACTION_TYPES {
   INIT_GAME = 'GAME-INIT_GAME',
   UPDATE_GAME = 'GAME-UPDATE_GAME',
+  DISMISS_ALERT = 'GAME-DISMISS_ALERT',
 }
 
-export type InitGameAction = Action<GameState>;
-export const initGame = (gameState: GameState): InitGameAction => ({
+export type InitGameAction = Action<GameStateFromSocket>;
+export const initGame = (gameState: GameStateFromSocket): InitGameAction => ({
   type: GAME_ACTION_TYPES.INIT_GAME,
   payload: { ...gameState },
 });
 
-export type UpdateGameAction = Action<GameState>;
-export const updateGame = (gameState: GameState): UpdateGameAction => ({
+export type UpdateGameAction = Action<GameStateFromSocket>;
+export const updateGame = (
+  gameState: GameStateFromSocket
+): UpdateGameAction => ({
   type: GAME_ACTION_TYPES.UPDATE_GAME,
   payload: { ...gameState },
+});
+
+export type DismissAlertAction = Action<{ alertId: string }>;
+export const dismissAlert = (id: string): DismissAlertAction => ({
+  type: GAME_ACTION_TYPES.DISMISS_ALERT,
+  payload: { alertId: id },
 });

--- a/src/store/connectorHelpers/index.test.ts
+++ b/src/store/connectorHelpers/index.test.ts
@@ -5,9 +5,11 @@ import {
   getPlayersWithoutRole,
   getPlayersWithRole,
   getSelf,
+  getUnreadAlerts,
   getWerewolfVotes,
 } from '.';
 import { PLAYER_ROLE } from '../../types/player';
+import { ALERT_ICON } from '../reducers/game';
 
 describe('Store > Connector Helpers', () => {
   describe('getSelf', () => {
@@ -338,6 +340,49 @@ describe('Store > Connector Helpers', () => {
       const result = getWerewolfVotes(mockState);
 
       expect(result).toEqual({});
+    });
+  });
+
+  describe('getUnreadAlerts', () => {
+    it('returns applicable alerts', () => {
+      const mockState = {
+        game: {
+          alerts: [
+            // Should be ignored because the subject is the user
+            {
+              title: 'Test Title',
+              content: 'Test Content',
+              icon: ALERT_ICON.DEATH,
+              subject: 'Dave',
+              id: 'test-id-1',
+            },
+            // Should be ignored because dismissed = true
+            {
+              title: 'Test Title',
+              content: 'Test Content',
+              icon: ALERT_ICON.DEATH,
+              subject: 'James',
+              id: 'test-id-2',
+              dismissed: true,
+            },
+            // Applicable
+            {
+              title: 'Test Title',
+              content: 'Test Content',
+              icon: ALERT_ICON.DEATH,
+              subject: 'Mike',
+              id: 'test-id-3',
+            },
+          ],
+        },
+        user: {
+          name: 'Dave',
+        },
+      } as any;
+
+      const result = getUnreadAlerts(mockState);
+
+      expect(result).toEqual([mockState.game.alerts[2]]);
     });
   });
 });

--- a/src/store/connectorHelpers/index.ts
+++ b/src/store/connectorHelpers/index.ts
@@ -2,6 +2,7 @@ import { PHASE_NAME, WerewolfPhaseData } from '../../types/phase';
 import { Player, PLAYER_ROLE } from '../../types/player';
 import { logError } from '../../utils/logger';
 import { State } from '../reducers';
+import { Alert } from '../reducers/game';
 
 export const getSelf = (state: State): Player | undefined =>
   state.game?.players.find((player) => player.name === state.user.name);
@@ -68,18 +69,6 @@ export const getPlayersWithoutRole = (
 ): Player[] =>
   playersWithoutRole(role, excludeSelf, state.user?.name, state.game?.players);
 
-export const getOldPlayersWithoutRole = (
-  state: State,
-  role: PLAYER_ROLE,
-  excludeSelf = false
-): Player[] =>
-  playersWithoutRole(
-    role,
-    excludeSelf,
-    state.user?.name,
-    state.game?.oldPlayers
-  );
-
 export const getPhaseName = (state: State): PHASE_NAME | undefined =>
   state.game?.phase.name;
 
@@ -114,3 +103,8 @@ export const getWerewolfVotes = (state: State): { [key: string]: number } => {
 
   return werewolfVotes;
 };
+
+export const getUnreadAlerts = (state: State): Alert[] | undefined =>
+  state.game?.alerts.filter(
+    (alert) => !alert.dismissed && alert.subject !== state.user.name
+  );

--- a/src/store/reducers/game/index.test.ts
+++ b/src/store/reducers/game/index.test.ts
@@ -1,23 +1,38 @@
 import { PHASE_NAME } from '../../../types/phase';
 import {
+  DismissAlertAction,
   GAME_ACTION_TYPES,
   InitGameAction,
   UpdateGameAction,
 } from '../../actions/game';
-import gameReducer, { GameState } from '.';
+import gameReducer, { ALERT_ICON, GameState } from '.';
 import { PLAYER_ROLE, PLAYER_TEAM } from '../../../types/player';
+
+jest.mock('uuid', () => ({
+  v4: (): string => 'uuid-v4',
+}));
 
 describe('Store > Reducers > Game', () => {
   const mockGameState: GameState = {
     lobbyId: '123',
     villageName: 'Test Village',
-    players: [],
-    oldPlayers: [],
+    players: [
+      {
+        name: 'Timothy',
+        attributes: {
+          role: PLAYER_ROLE.UNKNOWN,
+          team: PLAYER_TEAM.UNKNOWN,
+          alive: true,
+        },
+      },
+    ],
     phase: {
       name: PHASE_NAME.LOBBY,
       data: undefined,
     },
+    alerts: [],
   };
+
   describe('with an unknown action', () => {
     const action = { type: 'UNKNOWN', payload: undefined };
 
@@ -44,45 +59,127 @@ describe('Store > Reducers > Game', () => {
     });
   });
 
-  describe(`with ${GAME_ACTION_TYPES.INIT_GAME} action`, () => {
-    const mockAction: InitGameAction = {
+  describe(`with ${GAME_ACTION_TYPES.UPDATE_GAME} action`, () => {
+    const mockAction: UpdateGameAction = {
       type: GAME_ACTION_TYPES.UPDATE_GAME,
       payload: { ...mockGameState, villageName: 'Another Village' },
     };
+
     it('throws as expected on null state', () => {
       expect(() => gameReducer(null, mockAction)).toThrow();
     });
 
     it('overwrites existing game state', () => {
-      expect(gameReducer(mockGameState, mockAction)).toEqual(
-        mockAction.payload
-      );
+      expect(gameReducer(mockGameState, mockAction)).toEqual({
+        ...mockAction.payload,
+        alerts: [],
+      });
+    });
+
+    describe('updates the alerts array as appropriate', () => {
+      it('creates a death alert', () => {
+        const mockAlertingAction: UpdateGameAction = {
+          type: GAME_ACTION_TYPES.UPDATE_GAME,
+          payload: {
+            ...mockGameState,
+            villageName: 'Updated Village',
+            players: [
+              {
+                name: 'Timothy',
+                attributes: {
+                  role: PLAYER_ROLE.BODYGUARD,
+                  team: PLAYER_TEAM.GOOD,
+                  alive: false,
+                },
+              },
+            ],
+          },
+        };
+
+        expect(gameReducer(mockGameState, mockAlertingAction)).toEqual({
+          ...mockAlertingAction.payload,
+          alerts: [
+            {
+              id: 'uuid-v4',
+              content:
+                'It appears as though Timothy died a tragic death. They were a Bodyguard, on the Good team.',
+              icon: 'DEATH',
+              title: 'Timothy was killed!',
+              subject: 'Timothy',
+            },
+          ],
+        });
+      });
+
+      it('creates a role alert', () => {
+        const mockAlertingAction: UpdateGameAction = {
+          type: GAME_ACTION_TYPES.UPDATE_GAME,
+          payload: {
+            ...mockGameState,
+            villageName: 'Updated Village',
+            players: [
+              {
+                name: 'Timothy',
+                attributes: {
+                  role: PLAYER_ROLE.UNKNOWN,
+                  team: PLAYER_TEAM.GOOD,
+                  alive: true,
+                },
+              },
+            ],
+          },
+        };
+
+        expect(gameReducer(mockGameState, mockAlertingAction)).toEqual({
+          ...mockAlertingAction.payload,
+          alerts: [
+            {
+              id: 'uuid-v4',
+              content: "You've found out some information! Aren't you clever!",
+              icon: 'TEAM_GOOD',
+              title: 'Timothy is Good',
+              subject: 'Timothy',
+            },
+          ],
+        });
+      });
     });
   });
 
-  describe(`with ${GAME_ACTION_TYPES.UPDATE_GAME} action`, () => {
-    const mockAction: UpdateGameAction = {
-      type: GAME_ACTION_TYPES.UPDATE_GAME,
-      payload: {
-        ...mockGameState,
-        villageName: 'Updated Village',
-        players: [
-          {
-            name: 'Timothy',
-            attributes: {
-              role: PLAYER_ROLE.MODERATOR,
-              team: PLAYER_TEAM.UNKNOWN,
-              alive: true,
-            },
-          },
-        ],
-      },
+  describe(`with ${GAME_ACTION_TYPES.DISMISS_ALERT} action`, () => {
+    const mockAction: DismissAlertAction = {
+      type: GAME_ACTION_TYPES.DISMISS_ALERT,
+      payload: { alertId: 'test-id' },
     };
 
-    it('updates previous players into state', () => {
-      expect(gameReducer(mockAction.payload, mockAction)).toEqual({
-        ...mockAction.payload,
-        oldPlayers: mockAction.payload.players,
+    it('throws as expected on null state', () => {
+      expect(() => gameReducer(null, mockAction)).toThrow();
+    });
+
+    it('throws as expected when it cannot find an applicable alert', () => {
+      expect(() => gameReducer(mockGameState, mockAction)).toThrow();
+    });
+
+    it('updates the dismissed alert within state', () => {
+      const mockAlert = {
+        title: 'Test Title',
+        content: 'Test Content',
+        icon: ALERT_ICON.DEATH,
+        subject: 'Dave',
+        id: 'test-id',
+      };
+
+      const result = gameReducer(
+        {
+          ...mockGameState,
+          alerts: [mockAlert],
+        },
+        mockAction
+      );
+
+      expect(result).toEqual({
+        ...mockGameState,
+        alerts: [{ ...mockAlert, dismissed: true }],
       });
     });
   });

--- a/src/store/reducers/game/index.ts
+++ b/src/store/reducers/game/index.ts
@@ -1,18 +1,35 @@
 import { Player } from '../../../types/player';
 import { Phases } from '../../../types/phase';
 import {
+  DismissAlertAction,
   GAME_ACTION_TYPES,
   InitGameAction,
   UpdateGameAction,
 } from '../../actions/game';
 import { Action } from '../../actions/types';
+import { calculatePlayerChanges } from '../../../utils/calculatePlayerChanges';
+
+export enum ALERT_ICON {
+  DEATH = 'DEATH',
+  TEAM_EVIL = 'TEAM_EVIL',
+  TEAM_GOOD = 'TEAM_GOOD',
+}
+
+export interface Alert {
+  id: string;
+  title: string;
+  content: string;
+  icon: ALERT_ICON;
+  subject: string; // player name
+  dismissed?: boolean;
+}
 
 export interface GameState {
   lobbyId: string; // the game join code used
   villageName: string;
   players: Player[];
   phase: Phases;
-  oldPlayers?: Player[];
+  alerts: Alert[];
 }
 
 export const gameReducer = (
@@ -21,15 +38,46 @@ export const gameReducer = (
 ): GameState | null => {
   switch (action.type) {
     case GAME_ACTION_TYPES.INIT_GAME:
-      return state ? state : { ...(action as InitGameAction).payload };
+      return state
+        ? state
+        : { ...(action as InitGameAction).payload, alerts: [] };
     case GAME_ACTION_TYPES.UPDATE_GAME:
       if (!state) {
         throw new Error('No game exists to update - needs init first');
       }
 
+      const payload = (action as UpdateGameAction).payload;
+
       return {
-        ...(action as UpdateGameAction).payload,
-        oldPlayers: [...state.players],
+        ...payload,
+        alerts: [
+          ...state.alerts,
+          ...calculatePlayerChanges(state.players, payload.players),
+        ],
+      };
+    case GAME_ACTION_TYPES.DISMISS_ALERT:
+      if (!state) {
+        throw new Error('No game exists to update - needs init first');
+      }
+
+      const alertId = (action as DismissAlertAction).payload.alertId;
+
+      const alerts = [...state.alerts];
+      const alert = alerts.find(
+        (alertFromState) => alertFromState.id === alertId
+      );
+
+      if (!alert) {
+        throw new Error(
+          'Could not find alert to dismiss with ID of ' + alertId
+        );
+      }
+
+      alert.dismissed = true;
+
+      return {
+        ...state,
+        alerts,
       };
     default:
       return state;

--- a/src/utils/calculatePlayerChanges/index.test.ts
+++ b/src/utils/calculatePlayerChanges/index.test.ts
@@ -1,0 +1,230 @@
+import { Player, PLAYER_ROLE, PLAYER_TEAM } from '../../types/player';
+
+import { calculatePlayerChanges } from '.';
+
+jest.mock('uuid', () => ({
+  v4: (): string => 'uuid-v4',
+}));
+
+describe('Utils > calculatePlayerChanges', () => {
+  describe('reports changes correctly', () => {
+    describe('detects kills', () => {
+      it('with a single player', () => {
+        const oldPlayers: Player[] = [
+          {
+            name: 'Timothy',
+            attributes: {
+              role: PLAYER_ROLE.UNKNOWN,
+              team: PLAYER_TEAM.UNKNOWN,
+              alive: true,
+            },
+          },
+        ];
+
+        const newPlayers: Player[] = [
+          {
+            name: 'Timothy',
+            attributes: {
+              role: PLAYER_ROLE.UNKNOWN,
+              team: PLAYER_TEAM.UNKNOWN,
+              alive: false,
+            },
+          },
+        ];
+
+        const result = calculatePlayerChanges(oldPlayers, newPlayers);
+
+        expect(result).toEqual([
+          {
+            content:
+              'It appears as though Timothy died a tragic death. They were a Unknown, on the Unknown team.',
+            icon: 'DEATH',
+            id: 'uuid-v4',
+            subject: 'Timothy',
+            title: 'Timothy was killed!',
+          },
+        ]);
+      });
+
+      it('with multiple players', () => {
+        const oldPlayers: Player[] = [
+          {
+            name: 'Timothy',
+            attributes: {
+              role: PLAYER_ROLE.UNKNOWN,
+              team: PLAYER_TEAM.UNKNOWN,
+              alive: true,
+            },
+          },
+          {
+            name: 'James',
+            attributes: {
+              role: PLAYER_ROLE.UNKNOWN,
+              team: PLAYER_TEAM.UNKNOWN,
+              alive: true,
+            },
+          },
+        ];
+
+        const newPlayers: Player[] = [
+          {
+            name: 'Timothy',
+            attributes: {
+              role: PLAYER_ROLE.UNKNOWN,
+              team: PLAYER_TEAM.UNKNOWN,
+              alive: true,
+            },
+          },
+          {
+            name: 'James',
+            attributes: {
+              role: PLAYER_ROLE.UNKNOWN,
+              team: PLAYER_TEAM.UNKNOWN,
+              alive: false,
+            },
+          },
+        ];
+
+        const result = calculatePlayerChanges(oldPlayers, newPlayers);
+
+        expect(result).toEqual([
+          {
+            content:
+              'It appears as though James died a tragic death. They were a Unknown, on the Unknown team.',
+            icon: 'DEATH',
+            id: 'uuid-v4',
+            subject: 'James',
+            title: 'James was killed!',
+          },
+        ]);
+      });
+    });
+
+    describe('detects team reveals', () => {
+      it('with a single player', () => {
+        const oldPlayers: Player[] = [
+          {
+            name: 'Timothy',
+            attributes: {
+              role: PLAYER_ROLE.UNKNOWN,
+              team: PLAYER_TEAM.UNKNOWN,
+              alive: true,
+            },
+          },
+        ];
+
+        const newPlayers: Player[] = [
+          {
+            name: 'Timothy',
+            attributes: {
+              role: PLAYER_ROLE.UNKNOWN,
+              team: PLAYER_TEAM.GOOD,
+              alive: true,
+            },
+          },
+        ];
+
+        const result = calculatePlayerChanges(oldPlayers, newPlayers);
+
+        expect(result).toEqual([
+          {
+            content: "You've found out some information! Aren't you clever!",
+            icon: 'TEAM_GOOD',
+            id: 'uuid-v4',
+            subject: 'Timothy',
+            title: 'Timothy is Good',
+          },
+        ]);
+      });
+
+      it('with multiple players', () => {
+        const oldPlayers: Player[] = [
+          {
+            name: 'Timothy',
+            attributes: {
+              role: PLAYER_ROLE.UNKNOWN,
+              team: PLAYER_TEAM.UNKNOWN,
+              alive: true,
+            },
+          },
+          {
+            name: 'James',
+            attributes: {
+              role: PLAYER_ROLE.UNKNOWN,
+              team: PLAYER_TEAM.UNKNOWN,
+              alive: true,
+            },
+          },
+        ];
+
+        const newPlayers: Player[] = [
+          {
+            name: 'Timothy',
+            attributes: {
+              role: PLAYER_ROLE.UNKNOWN,
+              team: PLAYER_TEAM.UNKNOWN,
+              alive: true,
+            },
+          },
+          {
+            name: 'James',
+            attributes: {
+              role: PLAYER_ROLE.UNKNOWN,
+              team: PLAYER_TEAM.EVIL,
+              alive: true,
+            },
+          },
+        ];
+
+        const result = calculatePlayerChanges(oldPlayers, newPlayers);
+
+        expect(result).toEqual([
+          {
+            content: "You've found out some information! Aren't you clever!",
+            icon: 'TEAM_EVIL',
+            id: 'uuid-v4',
+            subject: 'James',
+            title: 'James is Evil',
+          },
+        ]);
+      });
+    });
+
+    it('reports a kill over a team reveal', () => {
+      const oldPlayers: Player[] = [
+        {
+          name: 'Timothy',
+          attributes: {
+            role: PLAYER_ROLE.UNKNOWN,
+            team: PLAYER_TEAM.UNKNOWN,
+            alive: true,
+          },
+        },
+      ];
+
+      const newPlayers: Player[] = [
+        {
+          name: 'Timothy',
+          attributes: {
+            role: PLAYER_ROLE.BODYGUARD,
+            team: PLAYER_TEAM.GOOD,
+            alive: false,
+          },
+        },
+      ];
+
+      const result = calculatePlayerChanges(oldPlayers, newPlayers);
+
+      expect(result).toEqual([
+        {
+          content:
+            'It appears as though Timothy died a tragic death. They were a Bodyguard, on the Good team.',
+          icon: 'DEATH',
+          id: 'uuid-v4',
+          subject: 'Timothy',
+          title: 'Timothy was killed!',
+        },
+      ]);
+    });
+  });
+});

--- a/src/utils/calculatePlayerChanges/index.ts
+++ b/src/utils/calculatePlayerChanges/index.ts
@@ -1,0 +1,45 @@
+import { Alert, ALERT_ICON } from '../../store/reducers/game';
+import { Player, PLAYER_TEAM } from '../../types/player';
+import { createAlert } from '../createAlert';
+
+export const calculatePlayerChanges = (
+  oldPlayers: Player[],
+  newPlayers: Player[]
+): Alert[] => {
+  const changes: Alert[] = [];
+
+  oldPlayers.forEach((oldPlayer) => {
+    const newPlayer = newPlayers.find(
+      (player) => player.name === oldPlayer.name
+    );
+
+    if (!newPlayer) {
+      return;
+    }
+
+    if (newPlayer.attributes.alive !== oldPlayer.attributes.alive) {
+      changes.push(
+        createAlert({
+          title: `${newPlayer.name} was killed!`,
+          content: `It appears as though ${newPlayer.name} died a tragic death. They were a ${newPlayer.attributes.role}, on the ${newPlayer.attributes.team} team.`,
+          icon: ALERT_ICON.DEATH,
+          subject: newPlayer.name,
+        })
+      );
+    } else if (newPlayer.attributes.team !== oldPlayer.attributes.team) {
+      changes.push(
+        createAlert({
+          title: `${newPlayer.name} is ${newPlayer.attributes.team}`,
+          content: `You've found out some information! Aren't you clever!`,
+          icon:
+            newPlayer.attributes.team === PLAYER_TEAM.GOOD
+              ? ALERT_ICON.TEAM_GOOD
+              : ALERT_ICON.TEAM_EVIL,
+          subject: newPlayer.name,
+        })
+      );
+    }
+  });
+
+  return changes;
+};

--- a/src/utils/createAlert/index.test.ts
+++ b/src/utils/createAlert/index.test.ts
@@ -1,0 +1,22 @@
+import { createAlert } from '.';
+import { ALERT_ICON } from '../../store/reducers/game';
+
+jest.mock('uuid', () => ({
+  v4: (): string => 'uuid-v4',
+}));
+
+describe('Utils > createAlert', () => {
+  it('creates a valid alert', () => {
+    const mockInput = {
+      title: 'Test Title',
+      content: 'Test Content',
+      icon: ALERT_ICON.DEATH,
+      subject: 'Test Subject',
+    };
+
+    expect(createAlert(mockInput)).toEqual({
+      ...mockInput,
+      id: 'uuid-v4',
+    });
+  });
+});

--- a/src/utils/createAlert/index.ts
+++ b/src/utils/createAlert/index.ts
@@ -1,0 +1,21 @@
+import { v4 as uuidv4 } from 'uuid';
+
+import { Alert, ALERT_ICON } from '../../store/reducers/game';
+
+export const createAlert = ({
+  title,
+  content,
+  icon,
+  subject,
+}: {
+  title: string;
+  content: string;
+  icon: ALERT_ICON;
+  subject: string;
+}): Alert => ({
+  id: uuidv4(),
+  title,
+  content,
+  icon,
+  subject,
+});


### PR DESCRIPTION
## ✅ What & Why

Alerts are currently calculated by the `PlayerWrapper` component, using comparison of the `oldPlayers` and `players` sections of the Redux `game` state. This is sub-optimal for a couple of reasons:

- Browser alerts suck
- Storing a copy of the `oldPlayers` and letting a component handle alerting means we don't have control over how the alerts look

So this PR changes all that by:

- Adding an `Alerts` component
- Removing the `oldPlayers` section of the Redux `game` state, and instead implementing an `alerts` section
   - The calculation of these alerts is done when an update game action is received, removing the onus on the component to know what's up
   - The calculation of changes is done by a separate utility function
- Create a `dismissAlert` action that will interact with the store to dismiss said alerts

<!--- High level description of changes. Highlight expectations for code review. --->

## 🧪 Tests

- [x] Created/amended tests for any new/changed components
- [x] Created/amended tests for any new/changed functionality for the services
- [x] Created/amended tests for any new/changed functionality for the providers
- [x] Created/amended tests for any new/changed functionality for the Redux store
- [x] Created/amended tests for any new/changed functionality for utilities

<!-- Ensure you've covered what's required. Put an "x" between the square brackets to fill in the checkbox -->

## 📸 Screenshots

![image](https://user-images.githubusercontent.com/3977605/103098266-13bd8b00-4602-11eb-954b-ad46eee9cbb6.png)

<!--- Any necessary screenshots. If it's a UI change, there should be something here --->

## 📓 Notes

Sorry your `oldPlayers` bit had to go Mike! I had to put the alerts into redux so that I could dismiss them, which meant the `oldPlayers` -powered pattern was no longer needed 😢 

**Known Weirdness**

The Moderator gets a bunch of alerts to begin with (as many as there are players). This can be tidied up later but for now, meh it's a small inconvenience for the Mod but a lot more niceness for everyone else. 

The reason I've not tackled this in this PR is because it's not as simple as "if mod don't show alerts", because I still want to alert the mod to deaths of other players (ie when the Werewolves kill someone). We should really work on removing the necessity of a Mod... maybe we could use the same pattern as werewolf voting for lynch voting? But only when 50% of total players have voted does the lynch enact (as opposed to 100% of wolves agreeing as it is for their phase).

<!--- Anything else you may want to talk about/get feedback on relative to this work --->
